### PR TITLE
Fix relative url issue in SASS files & rename wp-block

### DIFF
--- a/resources/scss/blocks/_wp-block-cover.scss
+++ b/resources/scss/blocks/_wp-block-cover.scss
@@ -1,4 +1,4 @@
-.wp-block-cover-image {
+.wp-block-cover {
 	align-items: center;
 	background-position: center center;
 	background-size: cover;

--- a/resources/scss/editor.scss
+++ b/resources/scss/editor.scss
@@ -56,7 +56,7 @@
 @import "blocks/wp-block-categories";
 @import "blocks/wp-block-code";
 @import "blocks/wp-block-columns";
-@import "blocks/wp-block-cover-image";
+@import "blocks/wp-block-cover";
 @import "blocks/wp-block-embed";
 @import "blocks/wp-block-file";
 @import "blocks/wp-block-gallery";

--- a/resources/scss/screen.scss
+++ b/resources/scss/screen.scss
@@ -112,7 +112,7 @@
 @import "blocks/wp-block-categories";
 @import "blocks/wp-block-code";
 @import "blocks/wp-block-columns";
-@import "blocks/wp-block-cover-image";
+@import "blocks/wp-block-cover";
 @import "blocks/wp-block-embed";
 @import "blocks/wp-block-file";
 @import "blocks/wp-block-gallery";

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -62,7 +62,8 @@ module.exports = {
 					{
 						loader: 'css-loader',
 						options: {
-							sourceMap: ! isProduction
+							sourceMap: ! isProduction,
+							url: false
 						}
 					},
 					{


### PR DESCRIPTION
Using backround images in .scss files, the generated url’s are absolute by default. This fixes that. See also: https://github.com/webpack-contrib/css-loader#url